### PR TITLE
Enhancement/support deserialization of partial classes

### DIFF
--- a/src/OrderCloud.SDK.Tests/SdkTests.cs
+++ b/src/OrderCloud.SDK.Tests/SdkTests.cs
@@ -105,6 +105,85 @@ namespace OrderCloud.SDK.Tests
 			}, li);
 		}
 
+		/// <summary>
+		/// Support partial OrderCloud model deserialization.
+		/// Primarily for partial xp where the intention is to reduce xp bloat in OrderCloud, while still enforcing data types in a strongly typed class.
+		/// Complete OrderCloud models aren't necessarily expected to be deserialised as the OrderCloud API always returns the complete model,
+		/// however the xp models share the same class and interface inheritance to support serialization/deserialization.
+		/// </summary>
+		[Test]
+		public void can_deserialize_partial()
+		{
+			// Preparing an OrderCloud model that would be expected to be returned by the get product endpoint.
+			var product = new Product<CustomPartialXP>
+			{
+				Name = "MyProduct",
+				xp = new CustomPartialXP { Foo = "test" },
+				Description = "blah",
+				Inventory = new PartialInventory
+				{
+					QuantityAvailable = 999
+				}
+			};
+
+			var serializedProduct = OrderCloudClient.Serializer.Serialize(product);
+			var deserializedProduct = OrderCloudClient.Serializer.Deserialize<CustomPartialProduct<CustomPartialXP>>(serializedProduct);
+
+			// As the complete model is deserialized, we expect to see all properties be assigned to the Props dictionary.
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.OwnerID)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.DefaultPriceScheduleID)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.AutoForward)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ID)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.Name)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.Description)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.QuantityMultiplier)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ShipWeight)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ShipHeight)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ShipWidth)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ShipLength)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.Active)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.SpecCount)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.VariantCount)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.ShipFromAddressID)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.DefaultSupplierID)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.Returnable)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.Inventory)));
+			Assert.IsNotNull(deserializedProduct.Props.ContainsKey(nameof(product.xp)));
+
+			// All properties should be mapped, including default values.
+			Assert.AreEqual(product.OwnerID, deserializedProduct.OwnerID);
+			Assert.AreEqual(product.DefaultPriceScheduleID, deserializedProduct.DefaultPriceScheduleID);
+			Assert.AreEqual(product.AutoForward, deserializedProduct.AutoForward);
+			Assert.AreEqual(product.ID, deserializedProduct.ID);
+			Assert.AreEqual(product.Name, deserializedProduct.Name);
+			Assert.AreEqual(product.Description, deserializedProduct.Description);
+			Assert.AreEqual(product.QuantityMultiplier, deserializedProduct.QuantityMultiplier);
+			Assert.AreEqual(product.ShipWeight, deserializedProduct.ShipWeight);
+			Assert.AreEqual(product.ShipHeight, deserializedProduct.ShipHeight);
+			Assert.AreEqual(product.ShipWidth, deserializedProduct.ShipWidth);
+			Assert.AreEqual(product.ShipLength, deserializedProduct.ShipLength);
+			Assert.AreEqual(product.Active, deserializedProduct.Active);
+			Assert.AreEqual(product.SpecCount, deserializedProduct.SpecCount);
+			Assert.AreEqual(product.VariantCount, deserializedProduct.VariantCount);
+			Assert.AreEqual(product.ShipFromAddressID, deserializedProduct.ShipFromAddressID);
+			Assert.AreEqual(product.DefaultSupplierID, deserializedProduct.DefaultSupplierID);
+			Assert.AreEqual(product.Returnable, deserializedProduct.Returnable);
+
+			// We cannot deserialise a nested partial as the PartialProduct still specifies Inventory as the Inventory OrderCloud model,
+			// however OrderCloud API responses return the full model, so this is more an FYI.
+			//Assert.AreEqual(product.Inventory, deserializedProduct.Inventory);
+			Assert.AreEqual(product.Inventory.QuantityAvailable, deserializedProduct.Inventory.QuantityAvailable);
+
+			// The CustomPartialXP crudely overrides the Object.Equals method as an example, however unboxing the Props dictionary for equality checks may be something we wish to as a future enhancement.
+			Assert.AreEqual(product.xp, deserializedProduct.xp);
+			// Validating a handful
+			Assert.IsTrue(deserializedProduct.xp is CustomPartialXP);
+			Assert.AreEqual(1, deserializedProduct.xp.Props.Count, "Only the 'Foo' property should have been added to the Props dictionary.");
+			Assert.AreEqual(product.xp.Props.Count, deserializedProduct.xp.Props.Count, "Only the 'Foo' property should have been added to the Props dictionary.");
+			Assert.AreEqual(product.xp.Foo, deserializedProduct.xp.Foo);
+			Assert.AreEqual(product.xp.Bar, deserializedProduct.xp.Bar);
+		}
+
 		[Test]
 		public async Task can_provide_alternative_token() {
 			// prove that auth credentials are no longer required like in earlier versions
@@ -282,6 +361,44 @@ namespace OrderCloud.SDK.Tests
 			public int Bar { get; set; }
 		}
 
+		private class CustomPartialXP : OrderCloudModel, IPartial
+		{
+			public string Foo { get => GetProp<string>(nameof(Foo)); set => SetProp<string>(nameof(Foo), value); }
+			public int Bar { get => GetProp<int>(nameof(Bar)); set => SetProp<int>(nameof(Bar), value); }
+
+			// This is only included to unit test the xp comparison
+			public override bool Equals(object xp)
+			{
+				if (!(xp is CustomPartialXP))
+				{
+					return false;
+				}
+
+				var that = xp as CustomPartialXP;
+
+				if (this.Props.Count != that.Props.Count)
+				{
+					return false;
+				}
+
+				foreach (var pair in this.Props)
+				{
+					// We don't plan to unbox the Props, so this crude approach is just to demonstrate deserialising custom partial xp is possible.
+					if (pair.Value.ToString() != that.Props[pair.Key].ToString())
+					{
+						return false;
+					}
+				}
+
+				return this.Foo == that.Foo && this.Bar == that.Bar;
+			}
+
+			public override int GetHashCode()
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		private class CustomConfigData
 		{
 			public string Foo { get; set; }
@@ -292,6 +409,10 @@ namespace OrderCloud.SDK.Tests
 		class CustomAddress : Address<CustomXP> { }
 		class CustomLineItem : LineItem<CustomXP, LineItemProduct, LineItemVariant, CustomAddress, CustomAddress> { }
 		class CustomOrder : Order<CustomXP, CustomUser, CustomAddress> { }
+		class CustomPartialProduct : PartialProduct<CustomPartialXP> { }
+		class CustomPartialProduct<Txp> : CustomPartialProduct {
+			public new Txp xp { get => GetProp<Txp>("xp"); set => SetProp<Txp>("xp", value); }
+		}
 
 		private static class JsonAssert
 		{

--- a/src/OrderCloud.SDK/JsonConverters.cs
+++ b/src/OrderCloud.SDK/JsonConverters.cs
@@ -14,6 +14,8 @@ namespace OrderCloud.SDK
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) =>
 			JObject.FromObject(((OrderCloudModel)value).Props, serializer).WriteTo(writer);
 
+		public override bool CanRead { get { return false; } }
+
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
 			throw new NotImplementedException();
 


### PR DESCRIPTION
There are often instances where an OrderCloud model may be a host to a variety of contexts and as such, does not need to store irrelevant information. For example, I product may be customised to represent a product bundle, with a `BundledProductIDs` property added to the xp. This property, even if null, is irrelevant to other product types and therefore would ideally be omitted to prevent confusion.

In order to leverage partial xp class functionality, we need to be able to deserialize the xp class, which is currently not possible as it is not implemented in the JsonConverters for partial classes. The overridden property CanRead allows the deserialization to occur, and the updated unit tests show this in action allowing persisted xp to be deserialised to strongly typed partial xp classes.

Enhancement benefits:
- A consistent custom partial xp can be utilised for both full and partial models, without needing to define alternate custom xp, dynamic, or anonymous xp to leverage a subset of xp data.
- Prevents a GET request from deserialising a full xp model from a partially persisted xp, which will bloat the persisted xp on a subsequent PUT.
- Minimise bloated xp with persisted null/default values.

In order for solutions to leverage partial xp, I can update the docs regarding its usage. Draft notes are below.

Strongly Typed Partial xp

- Will need to inherit from `OrderCloudModel` and `IPartial`.
- Properties will need to be defined with `GetProp` and `SetProp` methods.
- Default values not supported.

```c#
public class CustomPartialXP : OrderCloudModel, IPartial
{
	public string Foo { get => GetProp<string>(nameof(Foo)); set => SetProp<string>(nameof(Foo), value); }
	public int Bar { get => GetProp<int>(nameof(Bar)); set => SetProp<int>(nameof(Bar), value); }
}
```

- Set xp in constructor to allow deserialization.

```c#
public class CustomProduct : Product<CustomPartialXP>
{
	public CustomProduct()
	{
		xp = new CustomPartialXP();
	}
}
```

- Set xp in constructor to allow deserialization.
- Override xp type in partial class.

```c#
public class CustomPartialProduct : PartialProduct<CustomPartialXP> {
	public CustomPartialProduct()
	{
		xp = new CustomPartialXP();
	}

	public new CustomPartialXP xp { get => GetProp<CustomPartialXP>(nameof(xp)); set => SetProp<CustomPartialXP>(nameof(xp), value); }
}
```

Note: while both the complete or partial class can be deserialised from an API call, as the complete model, excluding xp, is added to the class `Props`, it is effectively the same, so there is no benefit for deserializing to a partial class.

```c#
var product = await orderCloudClient.Products.GetAsync<CustomProduct>("productID");

// Avoid this as its less performant and achieves the same as deserializing to CustomProduct.
var partialProduct = await orderCloudClient.Products.GetAsync<CustomPartialProduct>("productID");
```