### PR TITLE
refresh workflow implemented for authentication

### DIFF
--- a/src/OrderCloud.SDK/OAuthModels.cs
+++ b/src/OrderCloud.SDK/OAuthModels.cs
@@ -37,4 +37,13 @@ namespace OrderCloud.SDK
 
 		public string client_secret { get; set; }
 	}
+	
+	internal class OAuthTokenRequestWithRefreshTokenGrant : OAuthTokenRequest 
+	{
+		public OAuthTokenRequestWithRefreshTokenGrant() {
+			grant_type = "refresh_token";
+		}
+        
+		public string refresh_token { get; set; }
+	}
 }

--- a/src/OrderCloud.SDK/OrderCloudClient.cs
+++ b/src/OrderCloud.SDK/OrderCloudClient.cs
@@ -48,6 +48,16 @@ namespace OrderCloud.SDK
 		/// Sends a token request to the OrderCloud authorization server using the OAuth2 client credentials grant flow.
 		/// </summary>
 		Task<TokenResponse> AuthenticateAsync(string clientID, string clientSecret, params ApiRole[] roles);
+		
+		/// <summary>
+		/// Sends a token request to the OrderCloud authorization server using the OAuth2 refresh_token grant flow.
+		/// </summary>
+		Task<TokenResponse> RefreshTokenAsync(string refreshToken);
+
+		/// <summary>
+		/// Sends a token request to the OrderCloud authorization server using the OAuth2 refresh_token grant flow.
+		/// </summary>
+		Task<TokenResponse> RefreshTokenAsync(string clientID, string refreshToken);
 	}
 
 	public partial class OrderCloudClient : IDisposable
@@ -115,6 +125,21 @@ namespace OrderCloud.SDK
 			};
 			return AuthenticateAsync(req);
 		}
+		
+		public Task<TokenResponse> RefreshTokenAsync(string refreshToken) {
+			return RefreshTokenAsync(Config.ClientId, refreshToken);
+		}
+        
+		public Task<TokenResponse> RefreshTokenAsync(string clientID, string refreshToken) {
+			Require(clientID, nameof(clientID));
+			Require(refreshToken, nameof(refreshToken));
+            
+			var req = new OAuthTokenRequestWithRefreshTokenGrant {
+				client_id = clientID,
+				refresh_token = refreshToken
+			};
+			return AuthenticateAsync(req);
+		}		
 
 		public void Dispose() => TokenResponse = null;
 


### PR DESCRIPTION
It is crucial to have the ability to refresh user access tokens without reauthentication with password grant flow. So, we suggest supporting standard OAuth refresh flow (through refresh tokens), described in the [official documentation](https://ordercloud.io/knowledge-base/authentication).