### PR TITLE
update EnsureTokenAsync method to support newer versions of Flurl

### DIFF
--- a/src/OrderCloud.SDK.Tests/SdkTests.cs
+++ b/src/OrderCloud.SDK.Tests/SdkTests.cs
@@ -119,6 +119,24 @@ namespace OrderCloud.SDK.Tests
 				httpTest.ShouldHaveMadeACall().WithHeader("Authorization", "Bearer some-other-token");
 			}
 		}
+        
+		[Test]
+		public async Task missing_bearer_token_obtains_new_token() {
+			var cli = new OrderCloudClient(new OrderCloudClientConfig {
+				ApiUrl = "https://fake.com",
+				AuthUrl = "https://fake.com",
+				ClientId = "client-id",
+				ClientSecret = "client-secret",
+			});
+
+			using (var httpTest = new HttpTest())
+			{
+				_ = await cli.Me.GetAsync();
+				httpTest
+					.ShouldHaveCalled("https://fake.com/oauth/token")
+					.WithoutHeader("Authorization");
+			}
+		}
 
 		[Test]
 		public void doesnt_serialize_api_readonly_properties() {

--- a/src/OrderCloud.SDK/OrderCloudClient.cs
+++ b/src/OrderCloud.SDK/OrderCloudClient.cs
@@ -201,7 +201,7 @@ namespace OrderCloud.SDK
 		private readonly SemaphoreSlim _authLock = new(1);
 
 		private async Task EnsureTokenAsync(FlurlCall call) {
-			if (call.Request.Headers.TryGetFirst("Authorization", out var value) && value != "Bearer ")
+			if (call.Request.Headers.TryGetFirst("Authorization", out var value) && value.TrimEnd() != "Bearer")
 				return; // a token was provided explicitly
 
 			if (!IsAuthenticated) {


### PR DESCRIPTION
This PR updates the check against `"Bearer"` from the `Authorization` header value in the `EnsureTokenAsync` method. Consuming projects with newer versions of Flurl, which trims header values in a later version, fail at this check and therefore no attempt to authenticate happens.

PR also includes a unit test to ensure that this method works inline with the original implementation.