### PR TITLE
add PublicKey model and GetPublicKeyAsync method to OrderCloudClient

### DIFF
--- a/src/OrderCloud.SDK.Tests/SdkTests.cs
+++ b/src/OrderCloud.SDK.Tests/SdkTests.cs
@@ -328,6 +328,15 @@ namespace OrderCloud.SDK.Tests
 			Assert.AreEqual(response.HttpStatus, HttpStatusCode.GatewayTimeout);
 		}
 
+
+		[Test]
+		public async Task can_get_public_key() {
+			using (var httpTest = new HttpTest()) {
+				await GetClient().GetPublicKeyAsync("keyid");
+				httpTest.ShouldHaveCalled("https://fake.com/oauth/certs/keyid");
+			}
+		}
+
 		private OrderCloudClient GetClient() => new OrderCloudClient(new OrderCloudClientConfig {
 			ApiUrl = "https://fake.com",
 			AuthUrl = "https://fake.com",

--- a/src/OrderCloud.SDK/OAuthModels.cs
+++ b/src/OrderCloud.SDK/OAuthModels.cs
@@ -48,4 +48,20 @@ namespace OrderCloud.SDK
 		public string refresh_token { get; set; }
 		public string client_secret { get; set; }
 	}
+
+	public class PublicKey : OrderCloudModel
+	{
+		/// <summary>Kty of the public key.</summary>
+		public string kty { get => GetProp<string>("kty"); set => SetProp<string>("kty", value); }
+		/// <summary>N of the public key.</summary>
+		public string n { get => GetProp<string>("n"); set => SetProp<string>("n", value); }
+		/// <summary>E of the public key.</summary>
+		public string e { get => GetProp<string>("e"); set => SetProp<string>("e", value); }
+		/// <summary>Alg of the public key.</summary>
+		public string alg { get => GetProp<string>("alg"); set => SetProp<string>("alg", value); }
+		/// <summary>Use of the public key.</summary>
+		public string use { get => GetProp<string>("use"); set => SetProp<string>("use", value); }
+		/// <summary>Kid of the public key.</summary>
+		public string kid { get => GetProp<string>("kid"); set => SetProp<string>("kid", value); }
+	}
 }

--- a/src/OrderCloud.SDK/OrderCloud.SDK.csproj
+++ b/src/OrderCloud.SDK/OrderCloud.SDK.csproj
@@ -4,7 +4,7 @@
 		<!-- https://docs.microsoft.com/en-us/dotnet/core/tools/csproj -->
 		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>0.18.4</Version>
+		<Version>0.18.5</Version>
 		<PackageId>OrderCloud.SDK</PackageId>
 		<Title>OrderCloud SDK</Title>
 		<Authors>Todd Menier</Authors>

--- a/src/OrderCloud.SDK/OrderCloudClient.cs
+++ b/src/OrderCloud.SDK/OrderCloudClient.cs
@@ -59,6 +59,11 @@ namespace OrderCloud.SDK
 		/// Sends a token request to the OrderCloud authorization server using the OAuth2 refresh_token grant flow.
 		/// </summary>
 		Task<TokenResponse> RefreshTokenAsync(string clientID, string refreshToken);
+
+		/// <summary>
+		/// Get a single cert public key. Returns a JSON Web Key (JWK). Can be used for validating the token was signed by OrderCloud.
+		/// </summary>
+		Task<PublicKey> GetPublicKeyAsync(string ID, string accessToken = null);
 	}
 
 	public partial class OrderCloudClient : IDisposable
@@ -151,6 +156,12 @@ namespace OrderCloud.SDK
 				client_secret = clientSecret
 			};
 			return AuthenticateAsync(req);
+		}
+
+		public async Task<PublicKey> GetPublicKeyAsync(string ID, string accessToken = null) {
+			return await Request("oauth", "certs", ID)
+				.WithOAuthBearerToken(accessToken)
+				.GetJsonAsync<PublicKey>();
 		}
 
 		public void Dispose() => TokenResponse = null;


### PR DESCRIPTION
This PR resolves issue #146. It restores the GetPublicKeyAsync method and PublicKey model on the SDK, but on the OrderCloudClient with other auth methods rather than in the previously removed Certs resource.